### PR TITLE
fix:  Improve buildEnvironment

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,13 @@ module.  If you write one yourself using async `fs`, please pull request and sha
 
 ##### NodeJS ES Modules (Recommended)
 
-```js
-import wjConfig, { buildEnvironment } from 'wj-config';
+```ts
+import wjConfig, { buildEnvironment, type EnvironmentName } from 'wj-config';
 import mainConfig from "./config.json" assert {type: 'json'}; // Importing data is a thing in NodeJS.
 
 // Obtain an environment object ahead of time to help setting configuration up.
-const env = buildEnvironment(process.env.NODE_ENV /*, ['my', 'own', 'environment', 'list'] */);
+const environments = ['Test', 'Staging', 'Production'] as const;
+const env = buildEnvironment(environments, process.env.NODE_ENV as EnvironmentName<typeof environments>);
 
 const configPromise = wjConfig()
     .addObject(mainConfig) // Main configuration JSON file.
@@ -199,7 +200,8 @@ use of [URL-Building Functions](https://github.com/WJSoftware/wj-config/wiki/Eng
 // This is why CommonJS is discouraged.  It makes things more complex.
 module.exports = (async function () {
     const { default: wjConfig, buildEnvironment } = await import('wj-config');
-    const env = buildEnvironment(process.env.NODE_ENV /*, ['my', 'own', 'environment', 'list'] */);
+    const environments = ['Test', 'Staging', 'Production'];
+    const env = buildEnvironment(environments, process.env.NODE_ENV);
     return wjConfig()
         .addObject(loadJsonFile('./config.json', true))
         .name('Main')
@@ -221,11 +223,12 @@ module.exports = (async function () {
 > section in the **Wiki**.  It can also work without top-level awaits, but in all honesty, I don't like it.  The 
 > **Wiki** also explains how to achieve this for Vite projects (Vue, Svelte, React, etc.).
 
-```js
-import wjConfig, { buildEnvironment } from 'wj-config';
+```ts
+import wjConfig, { buildEnvironment, type EnvironmentName } from 'wj-config';
 import mainConfig from './config.json'; // One may import data like this, or fetch it.
 
-const env = buildEnvironment(window.env.REACT_ENVIRONMENT /*, ['my', 'own', 'environment', 'list'] */);
+const environments = ['Test', 'Staging', 'Production'] as const;
+const env = buildEnvironment(environments, window.env.REACT_ENVIRONMENT as EnvironmentName<typeof environments>);
 const configPromise = wjConfig()
     .addObject(mainConfig)
     .name('Main') // Give data sources a meaningful name for value tracing purposes.
@@ -276,11 +279,12 @@ console.log(config.app.title);
 There are two possible ways to do conditional style per-environment configuration.  The shortest first using the 
 **Web Projects** sample:
 
-```javascript
-import wjConfig, { buildEnvironment } from 'wj-config';
+```ts
+import wjConfig, { buildEnvironment, type EnvironmentName } from 'wj-config';
 import mainConfig from './config.json';
 
-const env = buildEnvironment(window.env.REACT_ENVIRONMENT /*, ['my', 'own', 'environment', 'list'] */);
+const environments = ['Test', 'Staging', 'Production'] as const;
+const env = buildEnvironment(environments, window.env.REACT_ENVIRONMENT as EnvironmentName<typeof environments>);
 const config = wjConfig()
     .addObject(mainConfig)
     .name('Main')
@@ -302,19 +306,25 @@ It looks almost identical to the classic.  This one has a few advantages:
 This conditional style requires the call to `includeEnvironment()` and to be made *before* calling 
 `addPerEnvironment()`.  Make sure you define your environment names when creating the environment object:
 
-```javascript
-const env = buildEnvironment(window.env.REACT_ENVIRONMENT, ['myDev', 'myTest', 'myProd']);
+```ts
+const environments = ['myDev', 'myTest', 'myProd'] as const;
+const env = buildEnvironment(environments, window.env.REACT_ENVIRONMENT as EnvironmentName<typeof environments>);
 ```
 
 This way `addPerEnvironment()` knows your environment names.
 
 The longer way of the conditional style looks like this:
 
-```javascript
-import wjConfig, { buildEnvironment } from 'wj-config';
+```ts
+import wjConfig, { buildEnvironment, type EnvironmentName } from 'wj-config';
 import mainConfig from './config.json';
 
-const env = buildEnvironment(window.env.REACT_ENVIRONMENT);
+const environments = [
+    'Development',
+    'PreProduction',
+    'Production'
+] as const;
+const env = buildEnvironment(environments, window.env.REACT_ENVIRONMENT as EnvironmentName<typeof environments>);
 const config = wjConfig()
     .addObject(mainConfig)
     .name('Main')
@@ -332,8 +342,6 @@ const config = wjConfig()
 export default await config;
 ```
 
-> When not specified, the list of environments is `'Development'`, `'PreProduction'`, and `'Production'`.
-
 This one has advantages 2 and 3 above, plus allows for the possiblity of having completely different data source types 
 per environment.  Furthermore, this allows you to add more environment-specific data sources if, for example, a 
 particular environment requires 2 or more data sources.  95% of the time you'll need the short one only.
@@ -345,11 +353,12 @@ This works in **NodeJS** too.  There is a performance catch, though:  If in Node
 `addObject()` data source function, you'll be reading all per-environment configuration files, even the unqualified 
 ones.  To avoid this performance hit, pass a function to `addObject()` that, in turn, calls `loadJsonFile()`:
 
-```js
-import wjConfig, { buildEnvironment } from 'wj-config';
+```ts
+import wjConfig, { buildEnvironment, EnvironmentName } from 'wj-config';
 import mainConfig from "./config.json" assert {type: 'json'};
 
-const env = buildEnvironment(process.env.NODE_ENV);
+const environments = ['Test', 'Staging', 'Production'] as const;
+const env = buildEnvironment(environments, process.env.NODE_ENV as EnvironmentName<typeof environments>);
 
 const config = wjConfig()
     .addObject(mainConfig)

--- a/src/EnvironmentDefinition.ts
+++ b/src/EnvironmentDefinition.ts
@@ -3,11 +3,11 @@ import type { IEnvironmentDefinition, Traits } from "./wj-config.js";
 /**
  * Environment definition class used to specify the current environment as an object.
  */
-export class EnvironmentDefinition<TEnvironments extends string> implements IEnvironmentDefinition<TEnvironments> {
+export class EnvironmentDefinition<TEnvironment extends string> implements IEnvironmentDefinition<TEnvironment> {
     /**
      * Gets the environment's name.
      */
-    public readonly name: TEnvironments;
+    public readonly name: TEnvironment;
     /**
      * Gets the environment's assigned traits.
      */
@@ -18,7 +18,7 @@ export class EnvironmentDefinition<TEnvironments extends string> implements IEnv
      * @param name The name of the current environment.
      * @param traits The traits assigned to the current environment.
      */
-    constructor(name: TEnvironments, traits?: Traits) {
+    constructor(name: TEnvironment, traits?: Traits) {
         this.name = name;
         this.traits = traits ?? 0;
     }

--- a/src/builders/Builder.ts
+++ b/src/builders/Builder.ts
@@ -52,22 +52,12 @@ export class Builder<T extends Record<string, any> = {}> implements IBuilder<T> 
     }
 
     includeEnvironment<TEnvironments extends string, TEnvironmentKey extends string = "environment">(
-        valueOrEnv: TEnvironments | IEnvironment<TEnvironments>,
-        propNameOrEnvNames?: TEnvironments[] | TEnvironmentKey,
-        propertyName?: TEnvironmentKey
+        env: IEnvironment<TEnvironments>,
+        propertyName: TEnvironmentKey = 'environment' as TEnvironmentKey,
     ) {
         this.#impl._lastCallWasDsAdd = false;
-        const propName = (typeof propNameOrEnvNames === 'string' ? propNameOrEnvNames : propertyName) ?? 'environment';
-        const envNames = (propNameOrEnvNames && typeof propNameOrEnvNames !== 'string') ? propNameOrEnvNames : undefined;
-        let env: IEnvironment<TEnvironments>;
-        if (typeof valueOrEnv === 'object') {
-            env = valueOrEnv;
-        }
-        else {
-            env = buildEnvironment(valueOrEnv, envNames);
-        }
         const envSource: IEnvironmentSource<TEnvironments> = {
-            name: propName,
+            name: propertyName,
             environment: env
         };
         return new EnvAwareBuilder<TEnvironments, Omit<T, TEnvironmentKey> & IncludeEnvironment<TEnvironments, TEnvironmentKey>>(envSource, this.#impl);

--- a/src/wj-config.d.ts
+++ b/src/wj-config.d.ts
@@ -229,7 +229,10 @@ export interface IBuilder<T extends Record<string, any> = {}> {
     * @param env Previously created environment object.
     * @param propertyName Optional property name for the environment object.
     */
-    includeEnvironment<TEnvironments extends string, TEnvironmentKey extends string = "environment">(env: IEnvironment<TEnvironments>, propertyName?: TEnvironmentKey): IEnvAwareBuilder<TEnvironments, Omit<T, TEnvironmentKey> & IncludeEnvironment<TEnvironments, TEnvironmentKey>>;
+    includeEnvironment<TEnvironments extends string, TEnvironmentKey extends string = "environment">(
+        env: IEnvironment<TEnvironments>,
+        propertyName?: TEnvironmentKey
+    ): IEnvAwareBuilder<TEnvironments, Omit<T, TEnvironmentKey> & IncludeEnvironment<TEnvironments, TEnvironmentKey>>;
     /**
      * Creates URL functions in the final configuration object for URL's defined according to the wj-config standard.
      * @param wsPropertyNames Optional list of property names whose values are expected to be objects that contain 
@@ -552,3 +555,22 @@ export interface IEnvironmentDefinition<TEnvironments extends string> {
      */
     readonly traits: Traits
 }
+
+/**
+ * Utility type that extracts the environment names from a constant list of possible names.
+ * 
+ * @example
+ * ```ts
+ * const envs = ['Development', 'Staging', 'Production'] as const;
+ * type EnvName = EnvironmentName<typeof envs>; // 'Development' | 'Staging' | 'Production'
+ * 
+ * const env = buildEnvironment(process.env.NODE_ENV as EnvName, envs);
+ * env.isDevelopment(); // true if the current environment is 'Development'
+ * env.isStaging(); // true if the current environment is 'Staging'
+ * env.isProduction(); // true if the current environment is 'Production'
+ * ```
+ * 
+ * Without the type casting (`as EnvName`), the `isXXX()` functions would not show up in Intellisense, as the type of 
+ * `env` would be`IEnvironment<string>`.
+ */
+export type EnvironmentName<T extends readonly string[]> = T[number];

--- a/tests/buildEnvironment.test.js
+++ b/tests/buildEnvironment.test.js
@@ -14,7 +14,7 @@ describe('buildEnvironment', () => {
         const envName = 'Dev';
 
         // Act.
-        const act = () => buildEnvironment(envName, envNames);
+        const act = () => buildEnvironment(envNames, envName);
 
         // Assert.
         expect(act).to.throw(Error);
@@ -28,7 +28,7 @@ describe('buildEnvironment', () => {
         const envName = 'Dev';
 
         // Act.
-        const env = buildEnvironment(envName, testEnvNames);
+        const env = buildEnvironment(testEnvNames, envName);
 
         // Assert.
         expect(isConfigNode(env.current)).to.be.true;
@@ -39,7 +39,7 @@ describe('buildEnvironment', () => {
         const envName = 'Dev';
 
         // Act.
-        const env = buildEnvironment(envName, testEnvNames);
+        const env = buildEnvironment(testEnvNames, envName);
 
         // Assert.
         expect(env.all).to.have.same.members(testEnvNames);
@@ -49,7 +49,7 @@ describe('buildEnvironment', () => {
         const envName = 'Dev';
 
         // Act.
-        const env = buildEnvironment(envName, testEnvNames);
+        const env = buildEnvironment(testEnvNames, envName);
 
         // Assert.
         const foundFns = [];
@@ -63,7 +63,7 @@ describe('buildEnvironment', () => {
     });
     const missingEnvNameTest = (envDef) => {
         // Act.
-        const act = () => buildEnvironment(envDef, testEnvNames);
+        const act = () => buildEnvironment(testEnvNames, envDef);
 
         // Assert.
         expect(act).to.throw(Error);
@@ -73,7 +73,7 @@ describe('buildEnvironment', () => {
     describe('hasTraits', () => {
         const traitMismatchTest = (envDef, testTraits) => {
             // Arrange.
-            const env = buildEnvironment(envDef, testEnvNames);
+            const env = buildEnvironment(testEnvNames, envDef);
 
             // Act.
             const act = () => env.hasTraits(testTraits);
@@ -86,7 +86,7 @@ describe('buildEnvironment', () => {
         it('Should throw if given an array of string test traits when the current environment traits are of the numeric kind.', () => traitMismatchTest({ name: 'Dev', traits: 3 }, ['abc', 'def']));
         const runTestFn = (envDef, testTraits, expectedResult) => {
             // Arrange.
-            const env = buildEnvironment(envDef, testEnvNames);
+            const env = buildEnvironment(testEnvNames, envDef);
 
             // Act.
             const result = env.hasTraits(testTraits);
@@ -108,7 +108,7 @@ describe('buildEnvironment', () => {
     describe('hasAnyTrait', () => {
         const traitMismatchTest = (envDef, testTraits) => {
             // Arrange.
-            const env = buildEnvironment(envDef, testEnvNames);
+            const env = buildEnvironment(testEnvNames, envDef);
 
             // Act.
             const act = () => env.hasAnyTrait(testTraits);
@@ -120,7 +120,7 @@ describe('buildEnvironment', () => {
         it('Should throw if given a string test trait when the current environment traits are of the numeric kind.', () => traitMismatchTest({ name: 'Dev', traits: 3 }, ['abc', 'def']));
         const runTestFn = (envDef, testTraits, expectedResult) => {
             // Arrange.
-            const env = buildEnvironment(envDef, testEnvNames);
+            const env = buildEnvironment(testEnvNames, envDef);
 
             // Act.
             const result = env.hasAnyTrait(testTraits);


### PR DESCRIPTION
- Default environments complicate things; removed them.
- Added EnvironmentName<> type to help correctly type environments.

Fixes #61.