### PR TITLE
fix: Correct environment source typing

### DIFF
--- a/src/wj-config.d.ts
+++ b/src/wj-config.d.ts
@@ -37,7 +37,7 @@ export type InflateKey<TKey extends string, TValue extends ConfigurationValue, T
     } :
     {
         [K in FullKey]: TValue;
-    } : never;
+    } : {};
 
 /**
  * Inflates entire dictionaries into their corresponding final objects.


### PR DESCRIPTION
When an environment object source contained properties that didn't match with the expected pattern, the entire config was being typed as `never`.